### PR TITLE
Add basic book search scaffolding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,19 @@
 			"dependencies": {
 				"@apollo/client": "^3.13.8",
 				"@apollo/server": "^4.12.2",
+				"@emotion/react": "^11.11.3",
+				"@emotion/styled": "^11.11.3",
+				"@mui/material": "^5.15.14",
+				"axios": "^1.6.8",
 				"body-parser": "^2.2.0",
 				"cors": "^2.8.5",
 				"express": "^5.1.0",
 				"graphql": "^16.11.0",
 				"jsonwebtoken": "^9.0.2",
+				"jwt-decode": "^4.0.0",
 				"react": "^19.1.0",
-				"react-dom": "^19.1.0"
+				"react-dom": "^19.1.0",
+				"react-router-dom": "^6.22.3"
 			},
 			"devDependencies": {
 				"@eslint/js": "^9.25.0",
@@ -617,7 +623,6 @@
 			"version": "7.27.1",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
 			"integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.27.1",
@@ -673,7 +678,6 @@
 			"version": "7.27.5",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.5.tgz",
 			"integrity": "sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/parser": "^7.27.5",
@@ -717,7 +721,6 @@
 			"version": "7.27.1",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
 			"integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/traverse": "^7.27.1",
@@ -759,7 +762,6 @@
 			"version": "7.27.1",
 			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
 			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -769,7 +771,6 @@
 			"version": "7.27.1",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
 			"integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -803,7 +804,6 @@
 			"version": "7.27.5",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
 			"integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/types": "^7.27.3"
@@ -847,11 +847,19 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
+		"node_modules/@babel/runtime": {
+			"version": "7.27.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+			"integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
 		"node_modules/@babel/template": {
 			"version": "7.27.2",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
 			"integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
@@ -866,7 +874,6 @@
 			"version": "7.27.4",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.4.tgz",
 			"integrity": "sha512-oNcu2QbHqts9BtOWJosOVJapWjBDSxGCpFvikNR5TGDYDQf3JwpIoMzIKrvfoti93cLfPJEG4tH9SPVeyCGgdA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
@@ -885,7 +892,6 @@
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
 			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
@@ -895,7 +901,6 @@
 			"version": "7.27.6",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.6.tgz",
 			"integrity": "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.27.1",
@@ -904,6 +909,158 @@
 			"engines": {
 				"node": ">=6.9.0"
 			}
+		},
+		"node_modules/@emotion/babel-plugin": {
+			"version": "11.13.5",
+			"resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+			"integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^7.16.7",
+				"@babel/runtime": "^7.18.3",
+				"@emotion/hash": "^0.9.2",
+				"@emotion/memoize": "^0.9.0",
+				"@emotion/serialize": "^1.3.3",
+				"babel-plugin-macros": "^3.1.0",
+				"convert-source-map": "^1.5.0",
+				"escape-string-regexp": "^4.0.0",
+				"find-root": "^1.1.0",
+				"source-map": "^0.5.7",
+				"stylis": "4.2.0"
+			}
+		},
+		"node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+			"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+			"license": "MIT"
+		},
+		"node_modules/@emotion/cache": {
+			"version": "11.14.0",
+			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+			"integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+			"license": "MIT",
+			"dependencies": {
+				"@emotion/memoize": "^0.9.0",
+				"@emotion/sheet": "^1.4.0",
+				"@emotion/utils": "^1.4.2",
+				"@emotion/weak-memoize": "^0.4.0",
+				"stylis": "4.2.0"
+			}
+		},
+		"node_modules/@emotion/hash": {
+			"version": "0.9.2",
+			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+			"integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+			"license": "MIT"
+		},
+		"node_modules/@emotion/is-prop-valid": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.1.tgz",
+			"integrity": "sha512-/ACwoqx7XQi9knQs/G0qKvv5teDMhD7bXYns9N/wM8ah8iNb8jZ2uNO0YOgiq2o2poIvVtJS2YALasQuMSQ7Kw==",
+			"license": "MIT",
+			"dependencies": {
+				"@emotion/memoize": "^0.9.0"
+			}
+		},
+		"node_modules/@emotion/memoize": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+			"integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+			"license": "MIT"
+		},
+		"node_modules/@emotion/react": {
+			"version": "11.14.0",
+			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+			"integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"@emotion/babel-plugin": "^11.13.5",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+				"@emotion/utils": "^1.4.2",
+				"@emotion/weak-memoize": "^0.4.0",
+				"hoist-non-react-statics": "^3.3.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@emotion/serialize": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+			"integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+			"license": "MIT",
+			"dependencies": {
+				"@emotion/hash": "^0.9.2",
+				"@emotion/memoize": "^0.9.0",
+				"@emotion/unitless": "^0.10.0",
+				"@emotion/utils": "^1.4.2",
+				"csstype": "^3.0.2"
+			}
+		},
+		"node_modules/@emotion/sheet": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+			"integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+			"license": "MIT"
+		},
+		"node_modules/@emotion/styled": {
+			"version": "11.14.0",
+			"resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.0.tgz",
+			"integrity": "sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"@emotion/babel-plugin": "^11.13.5",
+				"@emotion/is-prop-valid": "^1.3.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+				"@emotion/utils": "^1.4.2"
+			},
+			"peerDependencies": {
+				"@emotion/react": "^11.0.0-rc.0",
+				"react": ">=16.8.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@emotion/unitless": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+			"integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+			"license": "MIT"
+		},
+		"node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+			"integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@emotion/utils": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+			"integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+			"license": "MIT"
+		},
+		"node_modules/@emotion/weak-memoize": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+			"integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+			"license": "MIT"
 		},
 		"node_modules/@esbuild/aix-ppc64": {
 			"version": "0.25.5",
@@ -1630,7 +1787,6 @@
 			"version": "0.3.8",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
 			"integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/set-array": "^1.2.1",
@@ -1645,7 +1801,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
 			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.0.0"
@@ -1655,7 +1810,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
 			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.0.0"
@@ -1665,19 +1819,227 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
 			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.25",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
 			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
+		},
+		"node_modules/@mui/core-downloads-tracker": {
+			"version": "5.17.1",
+			"resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.17.1.tgz",
+			"integrity": "sha512-OcZj+cs6EfUD39IoPBOgN61zf1XFVY+imsGoBDwXeSq2UHJZE3N59zzBOVjclck91Ne3e9gudONOeILvHCIhUA==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui-org"
+			}
+		},
+		"node_modules/@mui/material": {
+			"version": "5.17.1",
+			"resolved": "https://registry.npmjs.org/@mui/material/-/material-5.17.1.tgz",
+			"integrity": "sha512-2B33kQf+GmPnrvXXweWAx+crbiUEsxCdCN979QDYnlH9ox4pd+0/IBriWLV+l6ORoBF60w39cWjFnJYGFdzXcw==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.23.9",
+				"@mui/core-downloads-tracker": "^5.17.1",
+				"@mui/system": "^5.17.1",
+				"@mui/types": "~7.2.15",
+				"@mui/utils": "^5.17.1",
+				"@popperjs/core": "^2.11.8",
+				"@types/react-transition-group": "^4.4.10",
+				"clsx": "^2.1.0",
+				"csstype": "^3.1.3",
+				"prop-types": "^15.8.1",
+				"react-is": "^19.0.0",
+				"react-transition-group": "^4.4.5"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui-org"
+			},
+			"peerDependencies": {
+				"@emotion/react": "^11.5.0",
+				"@emotion/styled": "^11.3.0",
+				"@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@emotion/react": {
+					"optional": true
+				},
+				"@emotion/styled": {
+					"optional": true
+				},
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@mui/material/node_modules/react-is": {
+			"version": "19.1.0",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
+			"integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
+			"license": "MIT"
+		},
+		"node_modules/@mui/private-theming": {
+			"version": "5.17.1",
+			"resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.17.1.tgz",
+			"integrity": "sha512-XMxU0NTYcKqdsG8LRmSoxERPXwMbp16sIXPcLVgLGII/bVNagX0xaheWAwFv8+zDK7tI3ajllkuD3GZZE++ICQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.23.9",
+				"@mui/utils": "^5.17.1",
+				"prop-types": "^15.8.1"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui-org"
+			},
+			"peerDependencies": {
+				"@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@mui/styled-engine": {
+			"version": "5.16.14",
+			"resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.16.14.tgz",
+			"integrity": "sha512-UAiMPZABZ7p8mUW4akDV6O7N3+4DatStpXMZwPlt+H/dA0lt67qawN021MNND+4QTpjaiMYxbhKZeQcyWCbuKw==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.23.9",
+				"@emotion/cache": "^11.13.5",
+				"csstype": "^3.1.3",
+				"prop-types": "^15.8.1"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui-org"
+			},
+			"peerDependencies": {
+				"@emotion/react": "^11.4.1",
+				"@emotion/styled": "^11.3.0",
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@emotion/react": {
+					"optional": true
+				},
+				"@emotion/styled": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@mui/system": {
+			"version": "5.17.1",
+			"resolved": "https://registry.npmjs.org/@mui/system/-/system-5.17.1.tgz",
+			"integrity": "sha512-aJrmGfQpyF0U4D4xYwA6ueVtQcEMebET43CUmKMP7e7iFh3sMIF3sBR0l8Urb4pqx1CBjHAaWgB0ojpND4Q3Jg==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.23.9",
+				"@mui/private-theming": "^5.17.1",
+				"@mui/styled-engine": "^5.16.14",
+				"@mui/types": "~7.2.15",
+				"@mui/utils": "^5.17.1",
+				"clsx": "^2.1.0",
+				"csstype": "^3.1.3",
+				"prop-types": "^15.8.1"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui-org"
+			},
+			"peerDependencies": {
+				"@emotion/react": "^11.5.0",
+				"@emotion/styled": "^11.3.0",
+				"@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@emotion/react": {
+					"optional": true
+				},
+				"@emotion/styled": {
+					"optional": true
+				},
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@mui/types": {
+			"version": "7.2.24",
+			"resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.24.tgz",
+			"integrity": "sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@mui/utils": {
+			"version": "5.17.1",
+			"resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.17.1.tgz",
+			"integrity": "sha512-jEZ8FTqInt2WzxDV8bhImWBqeQRD99c/id/fq83H0ER9tFl+sfZlaAoCdznGvbSQQ9ividMxqSV2c7cC1vBcQg==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.23.9",
+				"@mui/types": "~7.2.15",
+				"@types/prop-types": "^15.7.12",
+				"clsx": "^2.1.1",
+				"prop-types": "^15.8.1",
+				"react-is": "^19.0.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui-org"
+			},
+			"peerDependencies": {
+				"@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@mui/utils/node_modules/react-is": {
+			"version": "19.1.0",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
+			"integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
+			"license": "MIT"
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -2026,6 +2388,16 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/@popperjs/core": {
+			"version": "2.11.8",
+			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+			"integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/popperjs"
+			}
+		},
 		"node_modules/@protobufjs/aspromise": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -2089,6 +2461,15 @@
 			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
 			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/@remix-run/router": {
+			"version": "1.23.0",
+			"resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+			"integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
 		},
 		"node_modules/@rolldown/pluginutils": {
 			"version": "1.0.0-beta.19",
@@ -2807,6 +3188,18 @@
 				"form-data": "^4.0.0"
 			}
 		},
+		"node_modules/@types/parse-json": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+			"integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+			"license": "MIT"
+		},
+		"node_modules/@types/prop-types": {
+			"version": "15.7.15",
+			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+			"integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+			"license": "MIT"
+		},
 		"node_modules/@types/qs": {
 			"version": "6.14.0",
 			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
@@ -2823,7 +3216,6 @@
 			"version": "19.1.8",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
 			"integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"csstype": "^3.0.2"
@@ -2837,6 +3229,15 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"@types/react": "^19.0.0"
+			}
+		},
+		"node_modules/@types/react-transition-group": {
+			"version": "4.4.12",
+			"resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+			"integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*"
 			}
 		},
 		"node_modules/@types/send": {
@@ -3364,6 +3765,32 @@
 				"postcss": "^8.1.0"
 			}
 		},
+		"node_modules/axios": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+			"integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+			"license": "MIT",
+			"dependencies": {
+				"follow-redirects": "^1.15.6",
+				"form-data": "^4.0.0",
+				"proxy-from-env": "^1.1.0"
+			}
+		},
+		"node_modules/babel-plugin-macros": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+			"integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.12.5",
+				"cosmiconfig": "^7.0.0",
+				"resolve": "^1.19.0"
+			},
+			"engines": {
+				"node": ">=10",
+				"npm": ">=6"
+			}
+		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -3496,7 +3923,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -3548,6 +3974,15 @@
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/clsx": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+			"integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/color-convert": {
@@ -3648,6 +4083,31 @@
 				"node": ">= 0.10"
 			}
 		},
+		"node_modules/cosmiconfig": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/parse-json": "^4.0.0",
+				"import-fresh": "^3.2.1",
+				"parse-json": "^5.0.0",
+				"path-type": "^4.0.0",
+				"yaml": "^1.10.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/cosmiconfig/node_modules/yaml": {
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+			"license": "ISC",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3667,7 +4127,6 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
 			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/debug": {
@@ -3735,6 +4194,16 @@
 				"node": ">=0.10"
 			}
 		},
+		"node_modules/dom-helpers": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+			"integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.8.7",
+				"csstype": "^3.0.2"
+			}
+		},
 		"node_modules/dunder-proto": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3792,6 +4261,15 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/error-ex": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+			"license": "MIT",
+			"dependencies": {
+				"is-arrayish": "^0.2.1"
 			}
 		},
 		"node_modules/es-define-property": {
@@ -3900,7 +4378,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
@@ -4263,6 +4740,12 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/find-root": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+			"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+			"license": "MIT"
+		},
 		"node_modules/find-up": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -4300,6 +4783,26 @@
 			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/follow-redirects": {
+			"version": "1.15.9",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+			"integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/RubenVerborgh"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0"
+			},
+			"peerDependenciesMeta": {
+				"debug": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/form-data": {
 			"version": "4.0.3",
@@ -4596,7 +5099,6 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
 			"integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"parent-module": "^1.0.0",
@@ -4632,6 +5134,27 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.10"
+			}
+		},
+		"node_modules/is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+			"license": "MIT"
+		},
+		"node_modules/is-core-module": {
+			"version": "2.16.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+			"integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+			"license": "MIT",
+			"dependencies": {
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-extglob": {
@@ -4713,7 +5236,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
 			"integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"jsesc": "bin/jsesc"
@@ -4727,6 +5249,12 @@
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
 			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/json-parse-even-better-errors": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
 			"license": "MIT"
 		},
 		"node_modules/json-schema-traverse": {
@@ -4809,6 +5337,15 @@
 			"dependencies": {
 				"jwa": "^1.4.1",
 				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jwt-decode": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+			"integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/keyv": {
@@ -5083,6 +5620,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/lines-and-columns": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+			"license": "MIT"
 		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
@@ -5553,13 +6096,30 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"callsites": "^3.0.0"
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/parse-json": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.0.0",
+				"error-ex": "^1.3.1",
+				"json-parse-even-better-errors": "^2.3.0",
+				"lines-and-columns": "^1.1.6"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/parseurl": {
@@ -5591,6 +6151,12 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/path-parse": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+			"license": "MIT"
+		},
 		"node_modules/path-to-regexp": {
 			"version": "8.2.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
@@ -5600,11 +6166,19 @@
 				"node": ">=16"
 			}
 		},
+		"node_modules/path-type": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
 			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
@@ -5689,6 +6263,12 @@
 			"engines": {
 				"node": ">= 0.10"
 			}
+		},
+		"node_modules/proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+			"license": "MIT"
 		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
@@ -5797,6 +6377,54 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/react-router": {
+			"version": "6.30.1",
+			"resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+			"integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@remix-run/router": "1.23.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8"
+			}
+		},
+		"node_modules/react-router-dom": {
+			"version": "6.30.1",
+			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+			"integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+			"license": "MIT",
+			"dependencies": {
+				"@remix-run/router": "1.23.0",
+				"react-router": "6.30.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8",
+				"react-dom": ">=16.8"
+			}
+		},
+		"node_modules/react-transition-group": {
+			"version": "4.4.5",
+			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+			"integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@babel/runtime": "^7.5.5",
+				"dom-helpers": "^5.0.1",
+				"loose-envify": "^1.4.0",
+				"prop-types": "^15.6.2"
+			},
+			"peerDependencies": {
+				"react": ">=16.6.0",
+				"react-dom": ">=16.6.0"
+			}
+		},
 		"node_modules/rehackt": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/rehackt/-/rehackt-0.1.0.tgz",
@@ -5815,11 +6443,30 @@
 				}
 			}
 		},
+		"node_modules/resolve": {
+			"version": "1.22.10",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+			"integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+			"license": "MIT",
+			"dependencies": {
+				"is-core-module": "^2.16.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/resolve-from": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
@@ -6139,6 +6786,15 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6171,6 +6827,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/stylis": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+			"integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+			"license": "MIT"
+		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6182,6 +6844,18 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/symbol-observable": {
@@ -6689,6 +7363,21 @@
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/yaml": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+			"integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			}
 		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,14 @@
 		"express": "^5.1.0",
 		"graphql": "^16.11.0",
 		"jsonwebtoken": "^9.0.2",
-		"react": "^19.1.0",
-		"react-dom": "^19.1.0"
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^6.22.3",
+        "@mui/material": "^5.15.14",
+        "@emotion/react": "^11.11.3",
+        "@emotion/styled": "^11.11.3",
+        "jwt-decode": "^4.0.0",
+        "axios": "^1.6.8"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.25.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,21 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { Routes, Route, Navigate } from 'react-router-dom';
+import Navbar from './components/Navbar.js';
+import HomePage from './pages/HomePage.js';
+import SavedBooks from './pages/SavedBooks.js';
+import LoginForm from './components/LoginForm.js';
+import SignupForm from './components/SignupForm.js';
 
-function App() {
-  const [count, setCount] = useState(0)
-
+export default function App() {
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+    <div>
+      <Navbar />
+      <Routes>
+        <Route path="/" element={<Navigate to="/home" />} />
+        <Route path="/home" element={<HomePage />} />
+        <Route path="/saved" element={<SavedBooks />} />
+        <Route path="/login" element={<LoginForm />} />
+        <Route path="/signup" element={<SignupForm />} />
+      </Routes>
+    </div>
+  );
 }
-
-export default App

--- a/src/apolloClient.ts
+++ b/src/apolloClient.ts
@@ -1,0 +1,21 @@
+import { ApolloClient, InMemoryCache, createHttpLink } from '@apollo/client';
+import { setContext } from '@apollo/client/link/context';
+
+const httpLink = createHttpLink({
+  uri: '/graphql',
+});
+
+const authLink = setContext((_, { headers }) => {
+  const token = localStorage.getItem('token');
+  return {
+    headers: {
+      ...headers,
+      authorization: token ? `Bearer ${token}` : '',
+    },
+  };
+});
+
+export const client = new ApolloClient({
+  link: authLink.concat(httpLink),
+  cache: new InMemoryCache(),
+});

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,0 +1,42 @@
+import { useMutation } from '@apollo/client';
+import { useNavigate } from 'react-router-dom';
+import { useContext, useState } from 'react';
+import { LOGIN_USER } from '../utils/mutations.js';
+import { AuthContext } from '../context/authContext.js';
+import { useForm } from '../utils/hooks.js';
+
+export default function LoginForm() {
+  const navigate = useNavigate();
+  const { login } = useContext(AuthContext);
+  const [errors, setErrors] = useState<string | null>(null);
+
+  const loginCallback = () => {
+    loginUser();
+  };
+
+  const { onChange, onSubmit, values } = useForm(loginCallback, {
+    email: '',
+    password: '',
+  });
+
+  const [loginUser] = useMutation(LOGIN_USER, {
+    variables: { loginInput: values },
+    onCompleted(data) {
+      login(data.loginUser);
+      navigate('/');
+    },
+    onError(err) {
+      setErrors(err.message);
+    },
+  });
+
+  return (
+    <form onSubmit={onSubmit}>
+      <h3>Login</h3>
+      <input name="email" placeholder="Email" onChange={onChange} />
+      <input name="password" type="password" placeholder="Password" onChange={onChange} />
+      {errors && <p>{errors}</p>}
+      <button type="submit">Login</button>
+    </form>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,20 @@
+import { Link } from 'react-router-dom';
+import { useContext } from 'react';
+import { AuthContext } from '../context/authContext.js';
+
+export default function Navbar() {
+  const { user, logout } = useContext(AuthContext);
+  return (
+    <nav>
+      <Link to="/">Home</Link> |{' '}
+      <Link to="/saved">Saved Books</Link> |{' '}
+      {user ? (
+        <button onClick={logout}>Logout</button>
+      ) : (
+        <>
+          <Link to="/login">Login</Link> | <Link to="/signup">Signup</Link>
+        </>
+      )}
+    </nav>
+  );
+}

--- a/src/components/SaveBookBtn.tsx
+++ b/src/components/SaveBookBtn.tsx
@@ -1,0 +1,24 @@
+import { useMutation } from '@apollo/client';
+import { SAVE_BOOK } from '../utils/mutations.js';
+
+interface Book {
+  bookId: string;
+  title: string;
+  authors?: string[];
+  description?: string;
+  image?: string;
+  link?: string;
+}
+
+export default function SaveBookBtn({ book }: { book: Book }) {
+  const [saveBook, { loading }] = useMutation(SAVE_BOOK, {
+    variables: { book },
+    refetchQueries: ['user'],
+  });
+
+  return (
+    <button onClick={() => saveBook()} disabled={loading}>
+      {loading ? 'Saving...' : 'Save Book'}
+    </button>
+  );
+}

--- a/src/components/SearchBooks.tsx
+++ b/src/components/SearchBooks.tsx
@@ -1,0 +1,49 @@
+import { useLazyQuery } from '@apollo/client';
+import { useContext } from 'react';
+import { SEARCH_BOOKS } from '../utils/queries.js';
+import { useForm } from '../utils/hooks.js';
+import { AuthContext } from '../context/authContext.js';
+import SaveBookBtn from './SaveBookBtn.js';
+
+interface Book {
+  bookId: string;
+  title: string;
+  authors?: string[];
+  description?: string;
+  image?: string;
+  link?: string;
+}
+
+export default function SearchBooks() {
+  const { user } = useContext(AuthContext);
+  const [searchBooks, { data, loading, error }] = useLazyQuery(SEARCH_BOOKS);
+
+  const search = () => {
+    searchBooks({ variables: { query: values.search } });
+  };
+
+  const { onChange, onSubmit, values } = useForm(search, { search: '' });
+
+  return (
+    <div>
+      <form onSubmit={onSubmit}>
+        <input name="search" value={values.search} onChange={onChange} />
+        <button type="submit">Search</button>
+      </form>
+      {loading && <p>Loading...</p>}
+      {error && <p>Error: {error.message}</p>}
+      {data && (
+        <ul>
+          {data.searchBooks.map((book: Book) => (
+            <li key={book.bookId}>
+              <a href={book.link} target="_blank" rel="noreferrer">
+                {book.title}
+              </a>
+              {user && <SaveBookBtn book={book} />}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/SignupForm.tsx
+++ b/src/components/SignupForm.tsx
@@ -1,0 +1,44 @@
+import { useMutation } from '@apollo/client';
+import { useNavigate } from 'react-router-dom';
+import { useContext, useState } from 'react';
+import { REGISTER_USER } from '../utils/mutations.js';
+import { AuthContext } from '../context/authContext.js';
+import { useForm } from '../utils/hooks.js';
+
+export default function SignupForm() {
+  const navigate = useNavigate();
+  const { login } = useContext(AuthContext);
+  const [errors, setErrors] = useState<string | null>(null);
+
+  const signupCallback = () => {
+    registerUser();
+  };
+
+  const { onChange, onSubmit, values } = useForm(signupCallback, {
+    username: '',
+    email: '',
+    password: '',
+  });
+
+  const [registerUser] = useMutation(REGISTER_USER, {
+    variables: { registerInput: values },
+    onCompleted(data) {
+      login(data.registerUser);
+      navigate('/');
+    },
+    onError(err) {
+      setErrors(err.message);
+    },
+  });
+
+  return (
+    <form onSubmit={onSubmit}>
+      <h3>Sign Up</h3>
+      <input name="username" placeholder="Username" onChange={onChange} />
+      <input name="email" placeholder="Email" onChange={onChange} />
+      <input name="password" type="password" placeholder="Password" onChange={onChange} />
+      {errors && <p>{errors}</p>}
+      <button type="submit">Register</button>
+    </form>
+  );
+}

--- a/src/context/authContext.tsx
+++ b/src/context/authContext.tsx
@@ -1,0 +1,62 @@
+import { createContext, useReducer, ReactNode } from 'react';
+import jwtDecode from 'jwt-decode';
+
+interface UserToken {
+  id: string;
+  email: string;
+  exp?: number;
+}
+
+interface State {
+  user: UserToken | null;
+}
+
+interface Action {
+  type: 'LOGIN' | 'LOGOUT';
+  payload?: UserToken;
+}
+
+const token = localStorage.getItem('token');
+
+const initialState: State = {
+  user: token ? (jwtDecode(token) as UserToken) : null,
+};
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'LOGIN':
+      return { ...state, user: action.payload };
+    case 'LOGOUT':
+      return { ...state, user: null };
+    default:
+      return state;
+  }
+}
+
+export const AuthContext = createContext({
+  user: initialState.user,
+  login: (data: UserToken & { token: string }) => {
+    void data;
+  },
+  logout: () => {},
+});
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  const login = (data: UserToken & { token: string }) => {
+    localStorage.setItem('token', data.token);
+    dispatch({ type: 'LOGIN', payload: data });
+  };
+
+  const logout = () => {
+    localStorage.removeItem('token');
+    dispatch({ type: 'LOGOUT' });
+  };
+
+  return (
+    <AuthContext.Provider value={{ user: state.user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+import './server/index.js';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,20 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import { ApolloProvider } from '@apollo/client';
+import { AuthProvider } from './context/authContext.js';
+import { client } from './apolloClient.js';
+import './index.css';
+import App from './App.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ApolloProvider client={client}>
+      <AuthProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </AuthProvider>
+    </ApolloProvider>
   </StrictMode>,
-)
+);

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,0 +1,10 @@
+import SearchBooks from '../components/SearchBooks.js';
+
+export default function HomePage() {
+  return (
+    <div>
+      <h2>Book Finder</h2>
+      <SearchBooks />
+    </div>
+  );
+}

--- a/src/pages/SavedBooks.tsx
+++ b/src/pages/SavedBooks.tsx
@@ -1,0 +1,43 @@
+import { useQuery, useMutation } from '@apollo/client';
+import { QUERY_ME } from '../utils/queries.js';
+import { REMOVE_BOOK } from '../utils/mutations.js';
+import { useContext } from 'react';
+import { AuthContext } from '../context/authContext.js';
+
+interface Book {
+  bookId: string;
+  title: string;
+}
+
+export default function SavedBooks() {
+  const { user } = useContext(AuthContext);
+  const { data, loading, error, refetch } = useQuery(QUERY_ME, {
+    variables: { id: user?.id },
+    skip: !user,
+  });
+
+  const [removeBook] = useMutation(REMOVE_BOOK);
+
+  const handleRemove = async (bookId: string) => {
+    await removeBook({ variables: { bookId } });
+    refetch();
+  };
+
+  if (!user) return <p>Please log in</p>;
+  if (loading) return <p>Loading...</p>;
+  if (error) return <p>Error: {error.message}</p>;
+
+  return (
+    <div>
+      <h3>Your Saved Books</h3>
+      <ul>
+        {data?.user.savedBooks.map((book: Book) => (
+          <li key={book.bookId}>
+            {book.title}{' '}
+            <button onClick={() => handleRemove(book.bookId)}>Remove</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -1,0 +1,23 @@
+import { ExpressContextFunctionArgument } from '@apollo/server/dist/express4';
+import jwt from 'jsonwebtoken';
+
+const SECRET = 'replace-this-secret';
+
+export interface AuthUser {
+  id: string;
+  email: string;
+}
+
+export function createContext({ req }: ExpressContextFunctionArgument) {
+  const auth = req.headers.authorization || '';
+  if (auth.startsWith('Bearer ')) {
+    const token = auth.slice(7);
+    try {
+      const user = jwt.verify(token, SECRET) as AuthUser;
+      return { user };
+    } catch {
+      return { user: null };
+    }
+  }
+  return { user: null };
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,0 +1,28 @@
+import express from 'express';
+import { ApolloServer } from '@apollo/server';
+import { expressMiddleware } from '@apollo/server/express4';
+import cors from 'cors';
+import bodyParser from 'body-parser';
+import { typeDefs } from './typeDefs.js';
+import { resolvers } from './resolvers.js';
+import { createContext } from './context.js';
+
+const PORT = process.env.PORT || 4000;
+
+async function startServer() {
+  const server = new ApolloServer({ typeDefs, resolvers });
+  await server.start();
+
+  const app = express();
+  app.use(cors());
+  app.use(bodyParser.json());
+  app.use('/graphql', expressMiddleware(server, { context: createContext }));
+
+  app.listen(PORT, () => {
+    console.log(`🚀 Server ready at http://localhost:${PORT}/graphql`);
+  });
+}
+
+startServer().catch(err => {
+  console.error('Failed to start server', err);
+});

--- a/src/server/resolvers.ts
+++ b/src/server/resolvers.ts
@@ -1,0 +1,105 @@
+import axios from 'axios';
+import { v4 as uuidv4 } from 'uuid';
+import jwt from 'jsonwebtoken';
+import { Resolvers } from '@apollo/server';
+
+interface GoogleBook {
+  id: string;
+  volumeInfo: {
+    title: string;
+    authors?: string[];
+    description?: string;
+    imageLinks?: { thumbnail?: string };
+    infoLink?: string;
+  };
+}
+
+interface User {
+  id: string;
+  username: string;
+  email: string;
+  password: string;
+  savedBooks: Book[];
+}
+
+interface Book {
+  bookId: string;
+  title: string;
+  authors?: string[];
+  description?: string;
+  image?: string;
+  link?: string;
+}
+
+const SECRET = 'replace-this-secret';
+
+const users: User[] = [];
+
+function generateToken(user: User) {
+  return jwt.sign({ id: user.id, email: user.email }, SECRET, {
+    expiresIn: '2h',
+  });
+}
+
+export const resolvers: Resolvers = {
+  Query: {
+    async searchBooks(_, { query }) {
+      const res = await axios.get('https://www.googleapis.com/books/v1/volumes', {
+        params: { q: query },
+      });
+      return (
+        res.data.items || []
+      ).map((item: GoogleBook) => ({
+        bookId: item.id,
+        title: item.volumeInfo.title,
+        authors: item.volumeInfo.authors || [],
+        description: item.volumeInfo.description,
+        image: item.volumeInfo.imageLinks?.thumbnail,
+        link: item.volumeInfo.infoLink,
+      }));
+    },
+    user(_, { id }) {
+      return users.find(u => u.id === id) || null;
+    },
+    savedBooks(_, __, { user }) {
+      if (!user) throw new Error('Not authenticated');
+      const found = users.find(u => u.id === user.id);
+      return found ? found.savedBooks : [];
+    },
+  },
+  Mutation: {
+    registerUser(_, { registerInput }) {
+      const newUser: User = {
+        id: uuidv4(),
+        username: registerInput.username,
+        email: registerInput.email,
+        password: registerInput.password,
+        savedBooks: [],
+      };
+      const token = generateToken(newUser);
+      users.push(newUser);
+      return { ...newUser, token };
+    },
+    loginUser(_, { loginInput }) {
+      const user = users.find(u => u.email === loginInput.email && u.password === loginInput.password);
+      if (!user) throw new Error('Incorrect email or password');
+      return { ...user, token: generateToken(user) };
+    },
+    saveBook(_, { book }, { user }) {
+      if (!user) throw new Error('Not authenticated');
+      const found = users.find(u => u.id === user.id);
+      if (!found) throw new Error('User not found');
+      if (!found.savedBooks.some(b => b.bookId === book.bookId)) {
+        found.savedBooks.push(book);
+      }
+      return found;
+    },
+    removeBook(_, { bookId }, { user }) {
+      if (!user) throw new Error('Not authenticated');
+      const found = users.find(u => u.id === user.id);
+      if (!found) throw new Error('User not found');
+      found.savedBooks = found.savedBooks.filter(b => b.bookId !== bookId);
+      return found;
+    },
+  },
+};

--- a/src/server/typeDefs.ts
+++ b/src/server/typeDefs.ts
@@ -1,0 +1,53 @@
+import { gql } from 'graphql-tag';
+
+export const typeDefs = gql`
+  type User {
+    id: ID!
+    username: String!
+    email: String!
+    token: String!
+    savedBooks: [Book!]!
+  }
+
+  type Book {
+    bookId: String!
+    title: String!
+    authors: [String!]
+    description: String
+    image: String
+    link: String
+  }
+
+  input RegisterInput {
+    username: String!
+    email: String!
+    password: String!
+  }
+
+  input LoginInput {
+    email: String!
+    password: String!
+  }
+
+  input SaveBookInput {
+    bookId: String!
+    title: String!
+    authors: [String!]
+    description: String
+    image: String
+    link: String
+  }
+
+  type Query {
+    searchBooks(query: String!): [Book!]!
+    user(id: ID!): User
+    savedBooks: [Book!]!
+  }
+
+  type Mutation {
+    registerUser(registerInput: RegisterInput!): User!
+    loginUser(loginInput: LoginInput!): User!
+    saveBook(book: SaveBookInput!): User!
+    removeBook(bookId: String!): User!
+  }
+`;

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -1,0 +1,16 @@
+import { useState } from 'react';
+
+export function useForm<T>(callback: () => void, initialState: T) {
+  const [values, setValues] = useState(initialState);
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValues({ ...values, [e.target.name]: e.target.value });
+  };
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    callback();
+  };
+
+  return { onChange, onSubmit, values };
+}

--- a/src/utils/mutations.ts
+++ b/src/utils/mutations.ts
@@ -1,0 +1,50 @@
+import { gql } from '@apollo/client';
+
+export const LOGIN_USER = gql`
+  mutation loginUser($loginInput: LoginInput!) {
+    loginUser(loginInput: $loginInput) {
+      id
+      username
+      email
+      token
+    }
+  }
+`;
+
+export const REGISTER_USER = gql`
+  mutation registerUser($registerInput: RegisterInput!) {
+    registerUser(registerInput: $registerInput) {
+      id
+      username
+      email
+      token
+    }
+  }
+`;
+
+export const SAVE_BOOK = gql`
+  mutation SaveBook($book: SaveBookInput!) {
+    saveBook(book: $book) {
+      id
+      savedBooks {
+        bookId
+        title
+        authors
+        description
+        image
+        link
+      }
+    }
+  }
+`;
+
+export const REMOVE_BOOK = gql`
+  mutation RemoveBook($bookId: String!) {
+    removeBook(bookId: $bookId) {
+      id
+      savedBooks {
+        bookId
+      }
+    }
+  }
+`;

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -1,0 +1,32 @@
+import { gql } from '@apollo/client';
+
+export const QUERY_ME = gql`
+  query user($id: ID!) {
+    user(id: $id) {
+      id
+      username
+      email
+      savedBooks {
+        bookId
+        title
+        authors
+        description
+        image
+        link
+      }
+    }
+  }
+`;
+
+export const SEARCH_BOOKS = gql`
+  query SearchBooks($query: String!) {
+    searchBooks(query: $query) {
+      bookId
+      title
+      authors
+      description
+      image
+      link
+    }
+  }
+`;


### PR DESCRIPTION
## Summary
- scaffold server and client for book search
- add Apollo client and context for auth
- implement pages and components for searching and saving books
- set up simple GraphQL server with in-memory data
- update dependencies for routing and MUI

## Testing
- `npm run lint`
- `npm run compile`


------
https://chatgpt.com/codex/tasks/task_e_6859d86557088322a986192aa2cc67ef